### PR TITLE
Update core.yaml

### DIFF
--- a/core.yaml
+++ b/core.yaml
@@ -57,14 +57,6 @@ components:
       type: string
       description: An address city
       example: "Newark"
-    AddressType:
-      title: AddressType
-      type: string
-      description: A possible address type
-      default: BILLING
-      enum:
-        - MAILING
-        - BILLING
     CoreApiHashId:
       title: CoreApiHashId
       type: string
@@ -90,8 +82,6 @@ components:
         - state
       type: object
       properties:
-        type:
-          $ref: '#/components/schemas/AddressType'
         line1:
           $ref: '#/components/schemas/Line'
         line2:


### PR DESCRIPTION
Removing address type because each resource will maintain its own address and the type will be included in the field name (e.c billingAddress, mailingAddress, taxResidenceAddress)